### PR TITLE
fix: use build_container_path instead

### DIFF
--- a/torappu/core/tasks/audio.py
+++ b/torappu/core/tasks/audio.py
@@ -13,6 +13,7 @@ from torappu.models import Diff
 
 from .base import BaseTask
 from .utils import (
+    build_container_path,
     get_gamedata,
     read_obj,
     read_subprocess_stderr,
@@ -42,13 +43,14 @@ class Task(BaseTask):
 
     async def extract(self, real_path: str, ab_path: str):
         env = UnityPy.load(real_path)
+        container_map = build_container_path(env)
         for obj in filter(lambda obj: obj.type.name == "AudioClip", env.objects):
             if (clip := read_obj(AudioClip, obj)) is None:
                 continue
             for data in clip.samples.values():
                 if clip.object_reader is None:
                     continue
-                path = AUDIO_DIR / clip.object_reader.container.replace(
+                path = AUDIO_DIR / container_map[clip.object_reader.path_id].replace(
                     "dyn/audio/sound_beta_2/", ""
                 ).replace(".ogg", ".wav").replace("#", "__")
                 path.parent.mkdir(parents=True, exist_ok=True)

--- a/torappu/core/tasks/avg.py
+++ b/torappu/core/tasks/avg.py
@@ -15,6 +15,7 @@ from UnityPy.files.ObjectReader import ObjectReader
 
 from torappu.consts import STORAGE_DIR
 from torappu.core.tasks.utils import (
+    build_container_path,
     get_source,
     merge_alpha,
     read_obj,
@@ -32,7 +33,6 @@ ITEM_CONTAINER_PREFIX = "dyn/avg/items/"
 
 if TYPE_CHECKING:
     from UnityPy.files.SerializedFile import SerializedFile
-
 
 class Vector2Json(TypedDict):
     x: float
@@ -79,7 +79,6 @@ class CharacterDataJson(TypedDict):
 class NamedGameObject(Protocol):
     m_Name: str
     m_Components: list[PPtr[object]]
-
 
 def _vector_component(source: object, key: str) -> float:
     if isinstance(source, dict):
@@ -217,7 +216,9 @@ class CharacterSpriteGroup:
         )
 
     @classmethod
-    def from_legacy_object(cls, data: MonoBehaviour) -> "CharacterSpriteGroup | None":
+    def from_legacy_object(
+        cls, data: MonoBehaviour
+    ) -> "CharacterSpriteGroup | None":
         sprites = getattr(data, "sprites", None)
         if not isinstance(sprites, list):
             return None
@@ -590,6 +591,7 @@ class Task(BaseTask):
     async def unpack(
         self, env: UnityPy.Environment, unpacking_source: list[str]
     ) -> dict[str, CharacterDataJson]:
+        container_map = build_container_path(env)
         character_links: dict[str, CharacterDataJson] = {}
 
         for obj in env.objects:
@@ -597,7 +599,7 @@ class Task(BaseTask):
             if source not in unpacking_source:
                 continue
 
-            container_path = obj.container
+            container_path = container_map.get(obj.path_id)
             if container_path is None:
                 continue
 

--- a/torappu/core/tasks/camplogo.py
+++ b/torappu/core/tasks/camplogo.py
@@ -5,7 +5,7 @@ import UnityPy
 from UnityPy.classes import Sprite
 
 from torappu.consts import STORAGE_DIR
-from torappu.core.tasks.utils import read_obj
+from torappu.core.tasks.utils import build_container_path, read_obj
 from torappu.models import Diff
 
 from .base import BaseTask
@@ -19,11 +19,12 @@ class Task(BaseTask):
 
     async def unpack(self, ab_path: str):
         env = UnityPy.load(ab_path)
+        container_map = build_container_path(env)
         for obj in filter(lambda obj: obj.type.name == "Sprite", env.objects):
             if texture := read_obj(Sprite, obj):
                 if texture.object_reader is None:
                     continue
-                container_path = texture.object_reader.container
+                container_path = container_map[texture.object_reader.path_id]
                 path = BASE_DIR.joinpath(
                     container_path.replace("dyn/arts/camplogo/", "")
                 )

--- a/torappu/core/tasks/char_spine.py
+++ b/torappu/core/tasks/char_spine.py
@@ -14,6 +14,7 @@ from torappu.models import Diff
 
 from .base import BaseTask
 from .utils import (
+    build_container_path,
     get_gamedata,
     get_source,
     m_script_to_bytes,
@@ -126,6 +127,8 @@ class Task(BaseTask):
 
     @run_sync
     def unpack(self, env: UnityPy.Environment, unpacking_source: list[str]):
+        container_map = build_container_path(env)
+
         for obj in filter(lambda obj: obj.type.name == "GameObject", env.objects):
             source = get_source(obj)
             if source not in unpacking_source:
@@ -154,7 +157,7 @@ class Task(BaseTask):
             side = None
             if game_obj.object_reader is None:
                 continue
-            container_path = game_obj.object_reader.container
+            container_path = container_map[game_obj.object_reader.path_id]
             # 基建
             if container_path.startswith("dyn/building/vault/characters"):
                 # char_485_pallas_epoque_12 or

--- a/torappu/core/tasks/enemy_spine.py
+++ b/torappu/core/tasks/enemy_spine.py
@@ -12,6 +12,7 @@ from torappu.models import Diff
 
 from .base import BaseTask
 from .utils import (
+    build_container_path,
     get_source,
     m_script_to_bytes,
     material2img,
@@ -43,6 +44,8 @@ class Task(BaseTask):
 
     @run_sync
     def unpack_ab(self, env: UnityPy.Environment, unpacking_source: str):
+        container_map = build_container_path(env)
+
         def unpack(data: MonoBehaviour, path: str):
             dest_dir = STORAGE_DIR / "asset" / "raw" / "enemy_spine" / path
             dest_dir.mkdir(parents=True, exist_ok=True)
@@ -72,9 +75,11 @@ class Task(BaseTask):
                 continue
 
             if game_obj.m_Name == "Spine" and game_obj.object_reader is not None:
-                path = game_obj.object_reader.container.replace(
-                    "dyn/battle/prefabs/enemies/", ""
-                ).replace(".prefab", "")
+                path = (
+                    container_map[game_obj.object_reader.path_id]
+                    .replace("dyn/battle/prefabs/enemies/", "")
+                    .replace(".prefab", "")
+                )
                 for comp in filter(
                     lambda comp: comp.type.name == "MonoBehaviour",
                     game_obj.m_Components,

--- a/torappu/core/tasks/mixstory.py
+++ b/torappu/core/tasks/mixstory.py
@@ -6,7 +6,7 @@ from UnityPy.classes import Sprite
 
 from torappu.consts import STORAGE_DIR
 from torappu.core.client import Client
-from torappu.core.tasks.utils import read_obj
+from torappu.core.tasks.utils import build_container_path, read_obj
 from torappu.models import Diff
 
 from .base import BaseTask
@@ -24,11 +24,12 @@ class Task(BaseTask):
 
     async def unpack(self, ab_path: str):
         env = UnityPy.load(ab_path)
+        container_map = build_container_path(env)
         for obj in filter(lambda obj: obj.type.name == "Sprite", env.objects):
             if texture := read_obj(Sprite, obj):
                 if texture.object_reader is None:
                     continue
-                container_path = texture.object_reader.container
+                container_path = container_map[texture.object_reader.path_id]
 
                 # Map source directories to target directories
                 if container_path.startswith("dyn/arts/ui/mixstory/abbrs/"):

--- a/torappu/core/tasks/uniequip_direction.py
+++ b/torappu/core/tasks/uniequip_direction.py
@@ -6,8 +6,7 @@ import UnityPy
 from UnityPy.classes import Sprite
 
 from torappu.consts import STORAGE_DIR
-from torappu.core.client import Client
-from torappu.core.tasks.utils import read_obj
+from torappu.core.tasks.utils import build_container_path, read_obj
 from torappu.models import Diff
 
 from .base import BaseTask
@@ -19,16 +18,14 @@ class Task(BaseTask):
     priority: ClassVar[int] = 3
     name = "UniEquipDirection"
 
-    def __init__(self, client: Client) -> None:
-        super().__init__(client)
-
     async def unpack(self, ab_path: str):
         env = UnityPy.load(ab_path)
+        container_map = build_container_path(env)
         for obj in filter(lambda obj: obj.type.name == "Sprite", env.objects):
             if texture := read_obj(Sprite, obj):
                 if texture.object_reader is None:
                     continue
-                container_path = texture.object_reader.container
+                container_path = container_map[texture.object_reader.path_id]
                 filename = os.path.basename(container_path)
                 if not filename.lower().endswith(".png"):
                     filename = f"{filename}.png"

--- a/torappu/core/tasks/uniequip_type.py
+++ b/torappu/core/tasks/uniequip_type.py
@@ -6,8 +6,7 @@ import UnityPy
 from UnityPy.classes import Sprite
 
 from torappu.consts import STORAGE_DIR
-from torappu.core.client import Client
-from torappu.core.tasks.utils import read_obj
+from torappu.core.tasks.utils import build_container_path, read_obj
 from torappu.models import Diff
 
 from .base import BaseTask
@@ -19,16 +18,14 @@ class Task(BaseTask):
     priority: ClassVar[int] = 3
     name = "UniEquipType"
 
-    def __init__(self, client: Client) -> None:
-        super().__init__(client)
-
     async def unpack(self, ab_path: str):
         env = UnityPy.load(ab_path)
+        container_map = build_container_path(env)
         for obj in filter(lambda obj: obj.type.name == "Sprite", env.objects):
             if texture := read_obj(Sprite, obj):
                 if texture.object_reader is None:
                     continue
-                container_path = texture.object_reader.container
+                container_path = container_map[texture.object_reader.path_id]
                 filename = os.path.basename(container_path)
                 if not filename.lower().endswith(".png"):
                     filename = f"{filename}.png"

--- a/torappu/core/tasks/utils.py
+++ b/torappu/core/tasks/utils.py
@@ -3,6 +3,7 @@ from asyncio.subprocess import Process
 
 import numpy as np
 from PIL import Image
+from UnityPy import Environment
 from UnityPy.classes import FastPropertyName, Material, Texture2D, UnityTexEnv
 from UnityPy.files.ObjectReader import ObjectReader
 
@@ -74,6 +75,22 @@ def material2img(mat: Material):
                 rgbtexture = texture
 
     return merge_alpha(atexture, rgbtexture)
+
+
+# https://github.com/Perfare/AssetStudio/blob/master/AssetStudioGUI/Studio.cs#L210
+def build_container_path(env: Environment) -> dict[int, str]:
+    container_map: dict[int, str] = {}
+    for obj in filter(lambda obj: obj.type.name == "AssetBundle", env.objects):
+        typetree = obj.read_typetree()
+        table = typetree["m_PreloadTable"]
+        for path, info in typetree["m_Container"]:
+            for i in range(
+                info["preloadIndex"],
+                info["preloadIndex"] + info["preloadSize"],
+            ):
+                container_map[table[i]["m_PathID"]] = path
+
+    return container_map
 
 
 def m_script_to_bytes(script: str) -> bytes:


### PR DESCRIPTION
unityPy自带的.container没有算上m_PreloadTable 导致有的对象没有.container