### PR TITLE
feat: write gamedata-ready marker after decode

### DIFF
--- a/torappu/core/tasks/gamedata.py
+++ b/torappu/core/tasks/gamedata.py
@@ -4,6 +4,7 @@ import json
 import os
 import platform
 import struct
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
@@ -336,3 +337,24 @@ class Task(BaseTask):
                 f"./{self.client.version.res_version}",
                 True,
             )
+
+        ready_path = STORAGE_DIR.joinpath(
+            "asset",
+            "gamedata",
+            self.client.version.res_version,
+            ".gamedata-ready.json",
+        )
+        ready_path.parent.mkdir(parents=True, exist_ok=True)
+        ready_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "completedAt": datetime.now(UTC)
+                    .isoformat(timespec="seconds")
+                    .replace("+00:00", "Z"),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )

--- a/torappu/core/tasks/gamedata.py
+++ b/torappu/core/tasks/gamedata.py
@@ -4,7 +4,6 @@ import json
 import os
 import platform
 import struct
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
@@ -20,7 +19,7 @@ from torappu.consts import FBS_DIR, STORAGE_DIR
 from torappu.core.client import Client
 from torappu.core.tasks.utils import m_script_to_bytes
 from torappu.core.utils.thread import run_sync
-from torappu.models import Diff
+from torappu.models import Diff, GameDataReady
 
 from .base import BaseTask
 
@@ -346,15 +345,6 @@ class Task(BaseTask):
         )
         ready_path.parent.mkdir(parents=True, exist_ok=True)
         ready_path.write_text(
-            json.dumps(
-                {
-                    "schemaVersion": 1,
-                    "completedAt": datetime.now(UTC)
-                    .isoformat(timespec="seconds")
-                    .replace("+00:00", "Z"),
-                },
-                indent=2,
-            )
-            + "\n",
+            GameDataReady().model_dump_json(indent=2) + "\n",
             encoding="utf-8",
         )

--- a/torappu/models.py
+++ b/torappu/models.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -12,6 +13,13 @@ class Version(BaseModel):
 class VersionInfo(BaseModel):
     cur: Version
     prev: Version | None
+
+
+class GameDataReady(BaseModel):
+    schema_version: int = 1
+    completed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC).replace(microsecond=0)
+    )
 
 
 class ABInfo(BaseModel):


### PR DESCRIPTION
## Summary

- Write a `.gamedata-ready.json` marker at `storage/asset/gamedata/{res_version}/` after gamedata decode finishes
- Marker records `schemaVersion: 1` and a UTC `completedAt` timestamp (RFC 3339, second precision, `Z` suffix)
- Lets downstream tooling reliably detect that a full decoded gamedata set is available

## Testing

- Ran `uv run python -m torappu` for a version pair and confirmed `storage/asset/gamedata/{res_version}/.gamedata-ready.json` is created after decode
- Confirmed marker contains `schemaVersion: 1` and a `completedAt` value ending in `Z`
- Re-ran decode and confirmed the existing marker is refreshed with a new `completedAt`
- `uv run ruff check .` — Not run