### PR TITLE
feat(cli): 新增资源与 bundle 名称查找及 typetree 导出工具

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,17 @@ uv run python -m torappu.lookup --resolve-only <assetOrBundleName>
 uv run python -m torappu.lookup [--res <snapshot>] [--dump DIR] <assetName...>
 ```
 
-`--dump` walks every GameObject tree in the bundle and writes each
-MonoBehaviour typetree as `<pathID>.json` plus an `index.json` tree
-description under `DIR/<sanitized bundle name>/`. Note that shared bundles
-(`battle/prefabs/[uc]projectiles.ab` etc.) contain every character's prefabs;
-pick from `index.json` by GameObject name.
+`--dump` walks each root GameObject tree in the bundle and writes every
+MonoBehaviour typetree as `<serializedFile>_<pathID>.json` plus an
+`index.json` (pre-order, `depth` gives the nesting) under
+`DIR/<sanitized bundle name>/`; stale `*.json` from a previous dump of the
+same bundle are removed first. `--dump` cannot be combined with
+`--resolve-only`. Note that shared bundles (`battle/prefabs/[uc]projectiles.ab`
+etc.) contain every character's prefabs; pick from `index.json` by GameObject
+name.
+
+Bundle names come straight from the manifest, so both `*.ab` and `anon/*.bin`
+resolve as-is. Downloads, caching and retries go through
+`AssetBundleClient` (`torappu/core/assets.py`), the same code path the
+pipeline's `Client` uses, so `--res` also works for snapshots that were never
+synced locally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,21 @@ uv sync
 uv run ruff check .
 uv run ruff format .
 ```
+
+## Asset lookup (for reverse engineering)
+
+`torappu/lookup.py` resolves asset/bundle names and dumps prefab typetrees
+(manifest idx + hot_update_list + CDN download + UnityPy; reuses the shared
+`storage/assetbundle` cache):
+
+```bash
+uv run python -m torappu.lookup --search turdus              # substring -> asset\tbundle
+uv run python -m torappu.lookup --resolve-only <assetOrBundleName>
+uv run python -m torappu.lookup [--res <snapshot>] [--dump DIR] <assetName...>
+```
+
+`--dump` walks every GameObject tree in the bundle and writes each
+MonoBehaviour typetree as `<pathID>.json` plus an `index.json` tree
+description under `DIR/<sanitized bundle name>/`. Note that shared bundles
+(`battle/prefabs/[uc]projectiles.ab` etc.) contain every character's prefabs;
+pick from `index.json` by GameObject name.

--- a/torappu/core/__init__.py
+++ b/torappu/core/__init__.py
@@ -3,13 +3,10 @@ import pkgutil
 from collections import defaultdict
 
 import anyio
-import lz4inv
 import sentry_sdk
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.loguru import LoguruIntegration
-from UnityPy.enums.BundleFile import CompressionFlags
-from UnityPy.helpers.CompressionHelper import DECOMPRESSION_MAP
 
 from torappu import get_config
 from torappu.log import logger
@@ -18,8 +15,6 @@ from torappu.models import Diff, Version
 from .client import Client
 from .tasks.base import BaseTask
 
-# 2.5.04 25-04-03-14-16-11_4f0a01
-DECOMPRESSION_MAP[CompressionFlags.LZHAM] = lz4inv.decompress_buffer
 config = get_config()
 
 TASKS_MODULE_PATH = importlib.import_module("torappu.core.tasks").__path__

--- a/torappu/core/assets.py
+++ b/torappu/core/assets.py
@@ -1,0 +1,304 @@
+import asyncio
+import json
+from functools import cache
+from hashlib import md5
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from zipfile import ZipFile
+
+import httpx
+import UnityPy
+from ark_fbs import Options as FBOptions
+from ark_fbs import Schema as FBSchema
+from tenacity import retry, stop_after_attempt
+from UnityPy.classes import MonoBehaviour
+
+from torappu.config import Config
+from torappu.consts import (
+    ASSETS_DIR,
+    GAMEDATA_DIR,
+    HEADERS,
+    HG_CN_BASEURL,
+    HOT_UPDATE_LIST_DIR,
+    RESOURCE_MANIFEST_IDX_NAME,
+    STORAGE_DIR,
+)
+from torappu.core.utils.path import hg_normalize_url
+from torappu.core.utils.unity import install_unity_patches
+from torappu.log import logger
+from torappu.models import ABInfo, HotUpdateInfo
+
+install_unity_patches()
+
+ASSETBUNDLE_DIR = STORAGE_DIR / "assetbundle"
+
+
+@cache
+def resource_manifest_schema() -> FBSchema:
+    # 路径必须锚定到仓库根，否则从别的工作目录调用会找不到 schema
+    return FBSchema.from_fbs_file(
+        str(ASSETS_DIR / "ResourceManifest.fbs"),
+        include_paths=[str(ASSETS_DIR)],
+        options=FBOptions(),
+    )
+
+
+def _log_retry(name: str):
+    def _before_sleep(retry_state):
+        exc = (
+            retry_state.outcome.exception()
+            if retry_state.outcome and retry_state.outcome.failed
+            else None
+        )
+        # skipping self/cls in args
+        args = retry_state.args[1:] if retry_state.args else ()
+        call_args = ", ".join(
+            [
+                *(repr(a) for a in args),
+                *(f"{k}={v!r}" for k, v in retry_state.kwargs.items()),
+            ]
+        )
+        logger.warning(f"Retrying {name}({call_args}) after failure: {exc!r}")
+
+    return _before_sleep
+
+
+class AssetBundleClient:
+    """Resolve asset names to bundles and fetch bundles into the shared cache.
+
+    Everything here is scoped to a single ``res_version``; :class:`.client.Client`
+    builds the version diff and the anon prefetch the pipeline needs on top.
+    """
+
+    def __init__(self, res_version: str, config: Config) -> None:
+        self.res_version = res_version
+        self.config = config
+        self.http_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(config.timeout, pool=None),
+        )
+        self.hot_update_list: HotUpdateInfo
+        self.ab_infos: dict[str, ABInfo] = {}
+        self.asset_to_bundle: dict[str, str] = {}
+        self.downloaded: dict[str, Path] = {}
+        self._download_semaphore = asyncio.Semaphore(config.max_concurrent_downloads)
+        self._download_lock = asyncio.Lock()
+        self._downloading_tasks: dict[str, asyncio.Task[str]] = {}
+
+    async def init(self, *, prefer_cached_manifest: bool = False) -> None:
+        self.hot_update_list = await self.load_hot_update_list(self.res_version)
+        self.ab_infos = {info.name: info for info in self.hot_update_list.ab_infos}
+        await self.load_asset_to_bundle(prefer_cached=prefer_cached_manifest)
+
+    async def aclose(self) -> None:
+        await self.http_client.aclose()
+
+    def load_local_hot_update_list(self, res_version: str) -> HotUpdateInfo | None:
+        path = HOT_UPDATE_LIST_DIR.joinpath(res_version)
+
+        return (
+            HotUpdateInfo.model_validate_json(path.read_text(encoding="utf-8"))
+            if path.exists()
+            else None
+        )
+
+    @retry(
+        stop=stop_after_attempt(2),
+        before_sleep=_log_retry("load_remote_hot_update_list"),
+    )
+    async def load_remote_hot_update_list(self, res_version: str) -> HotUpdateInfo:
+        logger.debug(f"Downloading hot update list (res_version: {res_version})")
+
+        response = await self.http_client.get(
+            HG_CN_BASEURL.join(f"{res_version}/hot_update_list.json"),
+            headers=HEADERS,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        dest_path = HOT_UPDATE_LIST_DIR.joinpath(res_version)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text(response.text, encoding="utf-8")
+
+        return HotUpdateInfo.model_validate(result)
+
+    async def load_hot_update_list(self, res_version: str) -> HotUpdateInfo:
+        return self.load_local_hot_update_list(
+            res_version
+        ) or await self.load_remote_hot_update_list(res_version)
+
+    def get_abinfo_by_path(self, path: str) -> ABInfo:
+        info = self.ab_infos.get(path)
+        if info is None:
+            raise KeyError(
+                f"{path!r} is not in the hot update list of {self.res_version}"
+            )
+        return info
+
+    @retry(
+        stop=stop_after_attempt(2),
+        before_sleep=_log_retry("download_ab"),
+    )
+    async def download_ab(self, path: str) -> tuple[bytes, int]:
+        logger.debug(f"Downloading {path}")
+        filename = f"{hg_normalize_url(path.rsplit('.')[0])}.dat"
+        async with self._download_semaphore:
+            resp = await self.http_client.get(
+                HG_CN_BASEURL.join(f"{self.res_version}/{filename}")
+            )
+        resp.raise_for_status()
+        logger.debug(f"Downloaded {filename}")
+        crc = resp.headers.get("x-oss-hash-crc64ecma")
+        if crc is None:
+            raise RuntimeError(
+                f"{filename} response has no x-oss-hash-crc64ecma header, "
+                "cannot derive the cache key"
+            )
+        return (resp.content, int(crc))
+
+    def _check_cached_ab_path(
+        self, path: str, info: ABInfo, hashed_ab_path: Path
+    ) -> str | None:
+        if (
+            len(info.md5) != 4
+            and hashed_ab_path.exists()
+            and info.md5 == md5(hashed_ab_path.read_bytes()).hexdigest()
+        ):
+            return hashed_ab_path.as_posix()
+        if (
+            len(info.md5) == 4
+            and path in self.downloaded
+            and self.downloaded[path].exists()
+        ):
+            return str(self.downloaded[path].resolve())
+
+        return None
+
+    async def fetch_asset_bundle(self, path: str) -> str:
+        info = self.get_abinfo_by_path(path)
+
+        hashed_ab_path = ASSETBUNDLE_DIR / info.md5
+        cached = self._check_cached_ab_path(path, info, hashed_ab_path)
+        if cached is not None:
+            return cached
+
+        async with self._download_lock:
+            cached = self._check_cached_ab_path(path, info, hashed_ab_path)
+            if cached is not None:
+                return cached
+
+            if path in self._downloading_tasks:
+                task = self._downloading_tasks[path]
+            else:
+
+                async def _download_and_write(hashed_ab_path: Path) -> str:
+                    # 从 2.4.01 24-10-30-15-08-36-72419d 开始引入了anon/*
+                    # hot update list里面的md5只有四位，改用oss给的crc当文件名
+                    hashed_ab_path.parent.mkdir(parents=True, exist_ok=True)
+                    (content, crc) = await self.download_ab(path)
+                    if len(info.md5) == 4:
+                        hashed_ab_path = ASSETBUNDLE_DIR / str(crc)
+                        self.downloaded[path] = hashed_ab_path
+                    with ZipFile(BytesIO(content)) as myzip:
+                        hashed_ab_path.write_bytes(myzip.read(myzip.filelist[0]))
+
+                    return hashed_ab_path.as_posix()
+
+                task: asyncio.Task[str] = asyncio.create_task(
+                    _download_and_write(hashed_ab_path)
+                )
+
+                def cleanup(t: asyncio.Task[str]) -> None:
+                    existing = self._downloading_tasks.get(path)
+                    if existing is t:
+                        self._downloading_tasks.pop(path, None)
+
+                task.add_done_callback(cleanup)
+                self._downloading_tasks[path] = task
+
+        # 在锁外等待下载完成，避免阻塞其它 resolve
+        return await task
+
+    async def fetch_asset_bundles(self, path: list[str]) -> list[tuple[str, str]]:
+        result = await asyncio.gather(*(self.fetch_asset_bundle(p) for p in path))
+        return list(zip(path, result))
+
+    async def fetch_asset_bundles_by_prefix(self, prefix: str) -> list[str]:
+        paths = {name for name in self.ab_infos if name.startswith(prefix)}
+
+        if len(paths) == 0:
+            return []
+
+        return await asyncio.gather(*(self.fetch_asset_bundle(p) for p in paths))
+
+    async def fetch_asset_bundle_with_suffix(self, path: str) -> str:
+        return await self.fetch_asset_bundle(path + ".ab")
+
+    # [["abpath", "real_path"]]
+    async def fetch_asset_bundles_with_suffix(
+        self, path: list[str]
+    ) -> list[tuple[str, str]]:
+        result = await asyncio.gather(
+            *(self.fetch_asset_bundle_with_suffix(p) for p in path)
+        )
+        return list(zip(path, result))
+
+    async def load_asset_to_bundle(self, *, prefer_cached: bool = False) -> None:
+        if self.hot_update_list.manifest_name is None:
+            await self.load_torappu_index()
+            return
+
+        decoded_path = self.manifest_idx_path()
+        if prefer_cached and decoded_path.exists():
+            logger.debug(f"Reusing decoded manifest at {decoded_path}")
+            self.asset_to_bundle = self._build_asset_to_bundle(
+                json.loads(decoded_path.read_text(encoding="utf-8"))
+            )
+            return
+
+        idx_path = await self.fetch_asset_bundle(self.hot_update_list.manifest_name)
+        self.load_idx(idx_path)
+
+    def manifest_idx_path(self) -> Path:
+        return GAMEDATA_DIR.joinpath(self.res_version, RESOURCE_MANIFEST_IDX_NAME)
+
+    async def load_torappu_index(self):
+        path = await self.fetch_asset_bundle_with_suffix("torappu_index")
+        env = UnityPy.load(path)
+
+        torappu_index = env.container["dyn/torappu_index.asset"].read()
+
+        if torappu_index and isinstance(torappu_index, MonoBehaviour):
+            self.asset_to_bundle = {
+                item["assetName"]: item["bundleName"]
+                for item in torappu_index.assetToBundleList  # type: ignore
+            }
+
+    def load_idx(self, idx_path: str):
+        idx = Path(idx_path).read_bytes()
+        flatbuffer_data = idx[128:]
+        decoded_path = self.manifest_idx_path()
+        decoded_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            jsons = json.loads(
+                resource_manifest_schema().binary_to_json(flatbuffer_data)
+            )
+            decoded_path.write_text(
+                json.dumps(jsons, ensure_ascii=False, separators=(",", ":")),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to decode idx flatbuffer from {idx_path!r}"
+            ) from exc
+
+        self.asset_to_bundle = self._build_asset_to_bundle(jsons)
+
+    @staticmethod
+    def _build_asset_to_bundle(idx: dict[str, Any]) -> dict[str, str]:
+        bundles = idx["bundles"]
+        return {
+            item["assetName"]: bundles[item["bundleIndex"]]["name"]
+            for item in idx["assetToBundleList"]
+        }

--- a/torappu/core/client.py
+++ b/torappu/core/client.py
@@ -1,89 +1,33 @@
-import asyncio
-import json
-from hashlib import md5
-from io import BytesIO
-from pathlib import Path
-from zipfile import ZipFile
-
 import anyio
-import httpx
-import UnityPy
-from ark_fbs import Options as FBOptions
-from ark_fbs import Schema as FBSchema
-from tenacity import retry, stop_after_attempt
-from UnityPy.classes import MonoBehaviour
 
 from torappu.config import Config
-from torappu.consts import (
-    GAMEDATA_DIR,
-    HEADERS,
-    HG_CN_BASEURL,
-    HOT_UPDATE_LIST_DIR,
-    PRE_RESOLVE_PATHS,
-    RESOURCE_MANIFEST_IDX_NAME,
-    STORAGE_DIR,
-)
-from torappu.core.utils.path import hg_normalize_url
-from torappu.log import logger
-from torappu.models import ABInfo, Diff, HotUpdateInfo, Version
-
-resource_manifest_schema: FBSchema = FBSchema.from_fbs_file(
-    "assets/ResourceManifest.fbs",
-    include_paths=["assets"],
-    options=FBOptions(),
-)
+from torappu.consts import PRE_RESOLVE_PATHS
+from torappu.core.assets import AssetBundleClient
+from torappu.models import Diff, HotUpdateInfo, Version
 
 
-def _log_retry(name: str):
-    def _before_sleep(retry_state):
-        exc = (
-            retry_state.outcome.exception()
-            if retry_state.outcome and retry_state.outcome.failed
-            else None
-        )
-        # skipping self/cls in args
-        args = retry_state.args[1:] if retry_state.args else ()
-        call_args = ", ".join(
-            [
-                *(repr(a) for a in args),
-                *(f"{k}={v!r}" for k, v in retry_state.kwargs.items()),
-            ]
-        )
-        logger.warning(f"Retrying {name}({call_args}) after failure: {exc!r}")
+class Client(AssetBundleClient):
+    """Pipeline-facing client: a versioned :class:`AssetBundleClient` plus the
+    previous-version diff and the anon/refs prefetch tasks rely on."""
 
-    return _before_sleep
-
-
-class Client:
     def __init__(
         self, version: Version, prev_version: Version | None, config: Config
     ) -> None:
+        super().__init__(version.res_version, config)
         self.version = version
         self.prev_version = prev_version
-        self.config = config
-        self.http_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(config.timeout, pool=None),
-        )
-        self.asset_to_bundle: dict[str, str] = {}
-        self.downloaded: dict[str, Path] = {}
+        self.prev_hot_update_list: HotUpdateInfo | None = None
         self.anon_paths: set[str] = set()
-        self._download_semaphore = asyncio.Semaphore(config.max_concurrent_downloads)
-        self._download_lock = asyncio.Lock()
-        self._downloading_tasks: dict[str, asyncio.Task[str]] = {}
 
-    async def init(self):
-        self.hot_update_list = await self.load_hot_update_list(self.version.res_version)
+    async def init(self, *, prefer_cached_manifest: bool = False):
+        await super().init(prefer_cached_manifest=prefer_cached_manifest)
+
         if self.prev_version is not None and self.prev_version.res_version is not None:
             self.prev_hot_update_list = await self.load_hot_update_list(
                 self.prev_version.res_version
             )
         else:
             self.prev_hot_update_list = None
-        if self.hot_update_list.manifest_name is not None:
-            idx_path = await self.fetch_asset_bundle(self.hot_update_list.manifest_name)
-            self.load_idx(idx_path, self.hot_update_list.manifest_name)
-        else:
-            await self.load_torappu_index()
 
         await self.init_anon()
 
@@ -120,182 +64,3 @@ class Client:
             result.append(Diff(type="create", path=k))
 
         return result
-
-    def load_local_hot_update_list(self, res_version: str) -> HotUpdateInfo | None:
-        path = HOT_UPDATE_LIST_DIR.joinpath(res_version)
-
-        return (
-            HotUpdateInfo.model_validate_json(path.read_text(encoding="utf-8"))
-            if path.exists()
-            else None
-        )
-
-    @retry(
-        stop=stop_after_attempt(2),
-        before_sleep=_log_retry("load_remote_hot_update_list"),
-    )
-    async def load_remote_hot_update_list(self, res_version: str) -> HotUpdateInfo:
-        logger.debug(f"Downloading hot update list (res_version: {res_version})")
-
-        response = await self.http_client.get(
-            HG_CN_BASEURL.join(f"{res_version}/hot_update_list.json"),
-            headers=HEADERS,
-        )
-        result = response.json()
-
-        dest_path = HOT_UPDATE_LIST_DIR.joinpath(res_version)
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        dest_path.write_text(response.text, encoding="utf-8")
-
-        return HotUpdateInfo.model_validate(result)
-
-    async def load_hot_update_list(self, res_version: str) -> HotUpdateInfo:
-        return self.load_local_hot_update_list(
-            res_version
-        ) or await self.load_remote_hot_update_list(res_version)
-
-    def get_abinfo_by_path(self, path: str) -> ABInfo:
-        return next(
-            filter(lambda info: info.name == path, self.hot_update_list.ab_infos)
-        )
-
-    @retry(
-        stop=stop_after_attempt(2),
-        before_sleep=_log_retry("download_ab"),
-    )
-    async def download_ab(self, path: str) -> tuple[bytes, int]:
-        logger.debug(f"Downloading {path}")
-        filename = f"{hg_normalize_url(path.rsplit('.')[0])}.dat"
-        async with self._download_semaphore:
-            resp = await self.http_client.get(
-                HG_CN_BASEURL.join(f"{self.version.res_version}/{filename}")
-            )
-        logger.debug(f"Downloaded {filename}")
-        return (resp.content, int(resp.headers["x-oss-hash-crc64ecma"]))
-
-    def _check_cached_ab_path(
-        self, path: str, info: ABInfo, hashed_ab_path: Path
-    ) -> str | None:
-        if (
-            len(info.md5) != 4
-            and hashed_ab_path.exists()
-            and info.md5 == md5(hashed_ab_path.read_bytes()).hexdigest()
-        ):
-            return hashed_ab_path.as_posix()
-        if (
-            len(info.md5) == 4
-            and path in self.downloaded
-            and self.downloaded[path].exists()
-        ):
-            return str(self.downloaded[path].resolve())
-
-        return None
-
-    async def fetch_asset_bundle(self, path: str) -> str:
-        info = self.get_abinfo_by_path(path)
-
-        hashed_ab_path = STORAGE_DIR / "assetbundle" / info.md5
-        cached = self._check_cached_ab_path(path, info, hashed_ab_path)
-        if cached is not None:
-            return cached
-
-        async with self._download_lock:
-            cached = self._check_cached_ab_path(path, info, hashed_ab_path)
-            if cached is not None:
-                return cached
-
-            if path in self._downloading_tasks:
-                task = self._downloading_tasks[path]
-            else:
-
-                async def _download_and_write(hashed_ab_path: Path) -> str:
-                    # 从 2.4.01 24-10-30-15-08-36-72419d 开始引入了anon/*
-                    # hot update list里面的md5只有四位，改用oss给的crc当文件名
-                    hashed_ab_path.parent.mkdir(parents=True, exist_ok=True)
-                    (content, crc) = await self.download_ab(path)
-                    if len(info.md5) == 4:
-                        hashed_ab_path = STORAGE_DIR / "assetbundle" / str(crc)
-                        self.downloaded[path] = hashed_ab_path
-                    with ZipFile(BytesIO(content)) as myzip:
-                        hashed_ab_path.write_bytes(myzip.read(myzip.filelist[0]))
-
-                    return hashed_ab_path.as_posix()
-
-                task: asyncio.Task[str] = asyncio.create_task(
-                    _download_and_write(hashed_ab_path)
-                )
-
-                def cleanup(t: asyncio.Task[str]) -> None:
-                    existing = self._downloading_tasks.get(path)
-                    if existing is t:
-                        self._downloading_tasks.pop(path, None)
-
-                task.add_done_callback(cleanup)
-                self._downloading_tasks[path] = task
-
-        # 在锁外等待下载完成，避免阻塞其它 resolve
-        return await task
-
-    async def fetch_asset_bundles(self, path: list[str]) -> list[tuple[str, str]]:
-        result = await asyncio.gather(*(self.fetch_asset_bundle(p) for p in path))
-        return list(zip(path, result))
-
-    async def fetch_asset_bundles_by_prefix(self, prefix: str) -> list[str]:
-        paths = {
-            info.name
-            for info in self.hot_update_list.ab_infos
-            if info.name.startswith(prefix)
-        }
-
-        if len(paths) == 0:
-            return []
-
-        return await asyncio.gather(*(self.fetch_asset_bundle(p) for p in paths))
-
-    async def fetch_asset_bundle_with_suffix(self, path: str) -> str:
-        return await self.fetch_asset_bundle(path + ".ab")
-
-    # [["abpath", "real_path"]]
-    async def fetch_asset_bundles_with_suffix(
-        self, path: list[str]
-    ) -> list[tuple[str, str]]:
-        result = await asyncio.gather(
-            *(self.fetch_asset_bundle_with_suffix(p) for p in path)
-        )
-        return list(zip(path, result))
-
-    async def load_torappu_index(self):
-        path = await self.fetch_asset_bundle_with_suffix("torappu_index")
-        env = UnityPy.load(path)
-
-        torappu_index = env.container["dyn/torappu_index.asset"].read()
-
-        if torappu_index and isinstance(torappu_index, MonoBehaviour):
-            self.asset_to_bundle = {
-                item["assetName"]: item["bundleName"]
-                for item in torappu_index.assetToBundleList  # type: ignore
-            }
-
-    def load_idx(self, idx_path: str, manifest_name: str):
-        idx = Path(idx_path).read_bytes()
-        flatbuffer_data = idx[128:]
-        decoded_path = GAMEDATA_DIR.joinpath(
-            self.version.res_version, RESOURCE_MANIFEST_IDX_NAME
-        )
-        decoded_path.parent.mkdir(parents=True, exist_ok=True)
-
-        try:
-            jsons = json.loads(resource_manifest_schema.binary_to_json(flatbuffer_data))
-            decoded_path.write_text(
-                json.dumps(jsons, ensure_ascii=False, separators=(",", ":")),
-                encoding="utf-8",
-            )
-        except Exception as exc:
-            raise RuntimeError(
-                f"failed to decode idx flatbuffer from {idx_path!r}"
-            ) from exc
-
-        self.asset_to_bundle = {
-            item["assetName"]: jsons["bundles"][item["bundleIndex"]]["name"]
-            for item in jsons["assetToBundleList"]
-        }

--- a/torappu/core/utils/unity.py
+++ b/torappu/core/utils/unity.py
@@ -1,0 +1,13 @@
+import lz4inv
+from UnityPy.enums.BundleFile import CompressionFlags
+from UnityPy.helpers.CompressionHelper import DECOMPRESSION_MAP
+
+
+def install_unity_patches() -> None:
+    """Teach UnityPy about the custom compression HG ships.
+
+    Must run before any ``UnityPy.load()``; idempotent, so every entrypoint
+    that touches asset bundles can call it.
+    """
+    # 2.5.04 25-04-03-14-16-11_4f0a01
+    DECOMPRESSION_MAP[CompressionFlags.LZHAM] = lz4inv.decompress_buffer

--- a/torappu/lookup.py
+++ b/torappu/lookup.py
@@ -2,8 +2,8 @@
 
 Intended for reverse-engineering workflows: given an asset name seen in
 gamedata or a bundle name, tell which bundle contains it, fetch the bundle
-from the CDN (reusing the shared cache), and optionally dump deserialized
-typetrees of every GameObject tree inside.
+through the shared :class:`AssetBundleClient` cache, and optionally dump
+deserialized typetrees of every GameObject tree inside.
 
 Usage::
 
@@ -16,150 +16,244 @@ Usage::
 
 import json
 import re
-import zipfile
-from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+import anyio
 import click
-import httpx
 import UnityPy
+from UnityPy.classes import PPtr
+from UnityPy.environment import Environment
 from UnityPy.files.ObjectReader import ObjectReader
 
-import torappu.core  # noqa: F401  (patches DECOMPRESSION_MAP for custom lz4)
-from torappu.consts import (
-    GAMEDATA_DIR,
-    HG_CN_BASEURL,
-    HOT_UPDATE_LIST_DIR,
-    RESOURCE_MANIFEST_IDX_NAME,
-    STORAGE_DIR,
-)
-from torappu.core.utils.path import hg_normalize_url
-from torappu.models import ABInfo, HotUpdateInfo
+from torappu import get_config
+from torappu.consts import GAMEDATA_DIR, HOT_UPDATE_LIST_DIR
+from torappu.core.assets import AssetBundleClient
+from torappu.log import logger
 
 _SNAPSHOT_PATTERN = re.compile(r"^\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+$")
 MAX_SEARCH_RESULTS = 50
+# Transform 与 RectTransform 是不同的 ClassID，UI prefab 用的是后者
+TRANSFORM_TYPES = frozenset({"Transform", "RectTransform"})
 
 
 def _latest_res_version() -> str:
-    snapshots = sorted(
-        p.name
-        for p in GAMEDATA_DIR.iterdir()
-        if p.is_dir() and _SNAPSHOT_PATTERN.match(p.name)
-    )
+    snapshots = {
+        entry.name
+        for directory in (GAMEDATA_DIR, HOT_UPDATE_LIST_DIR)
+        if directory.is_dir()
+        for entry in directory.iterdir()
+        if _SNAPSHOT_PATTERN.match(entry.name)
+    }
     if not snapshots:
         raise click.ClickException(
-            f"no gamedata snapshot under {GAMEDATA_DIR}; run the sync pipeline first"
+            f"no snapshot under {GAMEDATA_DIR} or {HOT_UPDATE_LIST_DIR}; "
+            "run the sync pipeline first or pass --res"
         )
-    return snapshots[-1]
-
-
-def _load_manifest_idx(res_version: str) -> dict[str, str]:
-    idx_path = GAMEDATA_DIR / res_version / RESOURCE_MANIFEST_IDX_NAME
-    if not idx_path.exists():
-        raise click.ClickException(
-            f"{idx_path} not found; run the sync pipeline for {res_version} first"
-        )
-    idx = json.loads(idx_path.read_text(encoding="utf-8"))
-    bundles = idx["bundles"]
-    return {
-        item["assetName"]: bundles[item["bundleIndex"]]["name"]
-        for item in idx["assetToBundleList"]
-    }
-
-
-def _load_hot_update_list(res_version: str) -> HotUpdateInfo:
-    path = HOT_UPDATE_LIST_DIR / res_version
-    if not path.exists():
-        raise click.ClickException(
-            f"{path} not found; run the sync pipeline for {res_version} first"
-        )
-    return HotUpdateInfo.model_validate_json(path.read_text(encoding="utf-8"))
-
-
-def _download_bundle(info: ABInfo, res_version: str) -> Path:
-    """Mirror Client.fetch_asset_bundle caching (md5-named, crc for 4-char md5)."""
-    dest = STORAGE_DIR / "assetbundle" / info.md5
-    if len(info.md5) != 4 and dest.exists():
-        return dest
-
-    filename = f"{hg_normalize_url(info.name.rsplit('.')[0])}.dat"
-    url = HG_CN_BASEURL.join(f"{res_version}/{filename}")
-    with httpx.Client(timeout=120) as client:
-        resp = client.get(url)
-        resp.raise_for_status()
-        content = resp.content
-
-    with zipfile.ZipFile(BytesIO(content)) as bundle_zip:
-        blob = bundle_zip.read(bundle_zip.filelist[0])
-
-    if len(info.md5) == 4:
-        crc = resp.headers["x-oss-hash-crc64ecma"]
-        dest = STORAGE_DIR / "assetbundle" / crc
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_bytes(blob)
-    return dest
+    return max(snapshots)
 
 
 def _sanitize(name: str) -> str:
     return re.sub(r"[^0-9A-Za-z_.-]+", "_", name)
 
 
-def _dump_bundle(path: Path, dump_dir: Path) -> None:
-    env = UnityPy.load(str(path))
+def _deref(ptr: PPtr[Any], context: str) -> ObjectReader[Any]:
+    """Resolve a PPtr, reporting which pointer failed instead of skipping it."""
+    try:
+        return ptr.deref()
+    except Exception as exc:
+        raise RuntimeError(f"failed to resolve {context}") from exc
+
+
+def _root_transforms(env: Environment) -> list[tuple[ObjectReader[Any], Any]]:
+    """Transforms that no other transform in the bundle claims as a child.
+
+    ``env.objects`` yields every object in every serialized file, so walking it
+    directly would re-emit each nested node once per ancestor.
+    """
+    transforms = [
+        (obj, obj.read()) for obj in env.objects if obj.type.name in TRANSFORM_TYPES
+    ]
+    child_keys = {
+        (obj.assets_file.name, child.m_PathID)
+        for obj, data in transforms
+        for child in data.m_Children
+    }
+    return [
+        (obj, data)
+        for obj, data in transforms
+        if (obj.assets_file.name, obj.path_id) not in child_keys
+    ]
+
+
+def _dump_component(obj: ObjectReader[Any], dump_dir: Path) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "type": obj.type.name,
+        "pathID": obj.path_id,
+        "file": None,
+    }
+    if obj.type.name != "MonoBehaviour":
+        return record
+
+    try:
+        tree = obj.read_typetree()
+    except Exception as exc:
+        # 缺少 typetree 的 MonoBehaviour 是常态，记录下来但不要中断整个 dump
+        record["error"] = repr(exc)
+        click.echo(
+            f"warning: cannot read typetree of MonoBehaviour {obj.path_id}: {exc!r}",
+            err=True,
+        )
+        return record
+
+    # path_id 只在单个 SerializedFile 内唯一，必须带上所属文件名
+    filename = f"{_sanitize(obj.assets_file.name)}_{obj.path_id}.json"
+    (dump_dir / filename).write_text(
+        json.dumps(tree, ensure_ascii=False, indent=1, default=str),
+        encoding="utf-8",
+    )
+    record["file"] = filename
+    return record
+
+
+def _walk_game_object(
+    go: ObjectReader[Any], dump_dir: Path, depth: int
+) -> list[dict[str, Any]]:
+    data = go.read()
+    entry: dict[str, Any] = {
+        "gameObject": data.m_Name,
+        "pathID": go.path_id,
+        "depth": depth,
+        "components": [],
+    }
+    entries = [entry]
+
+    for index, ptr in enumerate(data.m_Components):
+        if ptr.m_PathID == 0:
+            # Unity 里丢失的组件序列化成空指针，是数据本身的状态
+            entry["components"].append({"type": None, "pathID": 0, "missing": True})
+            continue
+
+        obj = _deref(ptr, f"component {index} of GameObject {data.m_Name!r}")
+        entry["components"].append(_dump_component(obj, dump_dir))
+
+        if obj.type.name not in TRANSFORM_TYPES:
+            continue
+        # m_Children 里存的是 Transform 指针，要再跳一次才拿得到 GameObject
+        for child in obj.read().m_Children:
+            child_transform = _deref(
+                child, f"child transform of GameObject {data.m_Name!r}"
+            )
+            child_go = _deref(
+                child_transform.read().m_GameObject,
+                f"m_GameObject of {child_transform.type.name} "
+                f"{child_transform.path_id}",
+            )
+            entries.extend(_walk_game_object(child_go, dump_dir, depth + 1))
+
+    return entries
+
+
+def _prepare_dump_dir(dump_dir: Path) -> None:
     dump_dir.mkdir(parents=True, exist_ok=True)
+    stale = [path for path in dump_dir.glob("*.json") if path.is_file()]
+    for path in stale:
+        path.unlink()
+    if stale:
+        click.echo(f"removed {len(stale)} stale json file(s) from {dump_dir}")
+
+
+def _dump_bundle(bundle_path: str, dump_dir: Path) -> None:
+    env = UnityPy.load(bundle_path)
+    _prepare_dump_dir(dump_dir)
 
     index: list[dict[str, Any]] = []
-
-    def walk_game_object(go: ObjectReader, depth: int = 0) -> list[dict[str, Any]]:
-        entries: list[dict[str, Any]] = []
-        data = go.read()
-        entry: dict[str, Any] = {
-            "gameObject": data.m_Name,
-            "depth": depth,
-            "components": [],
-        }
-        for comp in data.m_Components:
-            try:
-                obj = comp.deref()
-            except Exception:
-                continue
-            if obj is None:
-                continue
-            if obj.type.name == "Transform":
-                for child in obj.read().m_Children:
-                    try:
-                        child_go = child.deref()
-                    except Exception:
-                        continue
-                    if child_go is not None and child_go.type.name == "GameObject":
-                        entries.extend(walk_game_object(child_go, depth + 1))
-                continue
-            record = {"type": obj.type.name, "pathID": obj.path_id, "file": None}
-            if obj.type.name == "MonoBehaviour":
-                try:
-                    tree = obj.read_typetree()
-                except Exception as exc:
-                    record["error"] = repr(exc)
-                else:
-                    fname = f"{obj.path_id}.json"
-                    (dump_dir / fname).write_text(
-                        json.dumps(tree, ensure_ascii=False, indent=1, default=str),
-                        encoding="utf-8",
-                    )
-                    record["file"] = fname
-            entry["components"].append(record)
-        entries.append(entry)
-        return entries
-
-    for obj in env.objects:
-        if obj.type.name == "GameObject":
-            index.extend(walk_game_object(obj))
+    for transform, data in _root_transforms(env):
+        go = _deref(
+            data.m_GameObject,
+            f"m_GameObject of root {transform.type.name} {transform.path_id}",
+        )
+        index.extend(_walk_game_object(go, dump_dir, 0))
 
     (dump_dir / "index.json").write_text(
         json.dumps(index, ensure_ascii=False, indent=1, default=str), encoding="utf-8"
     )
     click.echo(f"dumped typetrees to {dump_dir} (index.json describes the tree)")
+
+
+def _resolve_bundle(name: str, client: AssetBundleClient) -> str | None:
+    """Map an asset name, a bundle name, or a unique substring to a bundle name.
+
+    manifest 里的 bundle 名已经是 hot_update_list 里的完整名字（``*.ab`` 或
+    ``anon/*.bin``），不能再自己拼后缀。
+    """
+    bundle = client.asset_to_bundle.get(name)
+    if bundle is not None:
+        return bundle
+    if name in client.ab_infos:
+        return name
+    # 允许省略 .ab 后缀直接给 bundle 名
+    if f"{name}.ab" in client.ab_infos:
+        return f"{name}.ab"
+
+    needle = name.lower()
+    matches = {
+        asset: bundle
+        for asset, bundle in client.asset_to_bundle.items()
+        if needle in asset.lower()
+    }
+    if len(matches) == 1:
+        asset, bundle = next(iter(matches.items()))
+        click.echo(f"# '{name}' resolved to unique asset {asset}")
+        return bundle
+
+    click.echo(
+        f"# '{name}': not a known asset/bundle name "
+        f"({len(matches)} substring matches; use --search to list)"
+    )
+    return None
+
+
+async def _run(
+    names: tuple[str, ...],
+    res_version: str | None,
+    resolve_only: bool,
+    search: bool,
+    dump_dir: str | None,
+) -> None:
+    client = AssetBundleClient(res_version or _latest_res_version(), get_config())
+    try:
+        await client.init(prefer_cached_manifest=True)
+
+        if search:
+            for name in names:
+                needle = name.lower()
+                matches = sorted(
+                    (asset, bundle)
+                    for asset, bundle in client.asset_to_bundle.items()
+                    if needle in asset.lower()
+                )
+                click.echo(f"# '{name}': {len(matches)} asset matches")
+                for asset, bundle in matches[:MAX_SEARCH_RESULTS]:
+                    click.echo(f"{asset}\t{bundle}")
+            return
+
+        for name in names:
+            bundle = _resolve_bundle(name, client)
+            if bundle is None:
+                continue
+
+            info = client.get_abinfo_by_path(bundle)
+            click.echo(f"{name} -> {bundle} (md5 {info.md5}, {info.total_size} bytes)")
+            if resolve_only:
+                continue
+
+            path = await client.fetch_asset_bundle(bundle)
+            click.echo(f"bundle at {path}")
+            if dump_dir:
+                _dump_bundle(path, Path(dump_dir) / _sanitize(bundle))
+    finally:
+        await client.aclose()
 
 
 @click.command(
@@ -172,9 +266,12 @@ def _dump_bundle(path: Path, dump_dir: Path) -> None:
 @click.option(
     "--dump",
     "dump_dir",
-    type=click.Path(),
+    type=click.Path(file_okay=False),
     default=None,
     help="dump typetrees to DIR",
+)
+@click.option(
+    "--verbose", is_flag=True, help="keep the configured log level instead of WARNING"
 )
 def cli(
     name: tuple[str, ...],
@@ -182,61 +279,17 @@ def cli(
     resolve_only: bool,
     search: bool,
     dump_dir: str | None,
+    verbose: bool,
 ):
     if not name:
         raise click.ClickException("NAME is required")
-    res_version = res_version or _latest_res_version()
-    asset_to_bundle = _load_manifest_idx(res_version)
-    hot_update = _load_hot_update_list(res_version)
-    bundle_names = {info.name for info in hot_update.ab_infos}
+    if resolve_only and dump_dir:
+        raise click.ClickException("--resolve-only and --dump are mutually exclusive")
+    if not verbose:
+        # 结果走 stdout，默认别让 pipeline 的日志混进去
+        logger.configure(extra={"log_level": "WARNING"})
 
-    if search:
-        for n in name:
-            matches = [
-                (asset, bundle)
-                for asset, bundle in asset_to_bundle.items()
-                if n.lower() in asset.lower()
-            ]
-            matches.sort()
-            click.echo(f"# '{n}': {len(matches)} asset matches")
-            for asset, bundle in matches[:MAX_SEARCH_RESULTS]:
-                click.echo(f"{asset}\t{bundle}")
-        return
-
-    for n in name:
-        bundle = asset_to_bundle.get(n)
-        if bundle is None:
-            if n in bundle_names:
-                bundle = n
-            else:
-                partial = [
-                    (asset, b) for asset, b in asset_to_bundle.items() if n in asset
-                ]
-                if len(partial) == 1:
-                    bundle = partial[0][1]
-                    click.echo(f"# '{n}' resolved to unique asset {partial[0][0]}")
-                else:
-                    click.echo(
-                        f"# '{n}': not a known asset/bundle name "
-                        f"({len(partial)} substring matches; use --search to list)"
-                    )
-                    continue
-        ab_name = bundle if bundle.endswith(".ab") else f"{bundle}.ab"
-        info = next(
-            (i for i in hot_update.ab_infos if i.name == ab_name),
-            None,
-        )
-        if info is None:
-            click.echo(f"# '{n}' -> {ab_name}: not in hot_update_list")
-            continue
-        click.echo(f"{n} -> {ab_name} (md5 {info.md5}, {info.total_size} bytes)")
-
-        if resolve_only:
-            continue
-        path = _download_bundle(info, res_version)
-        click.echo(f"bundle at {path}")
-        if dump_dir:
-            _dump_bundle(path, Path(dump_dir) / _sanitize(ab_name))
+    anyio.run(_run, name, res_version, resolve_only, search, dump_dir)
 
 
 if __name__ == "__main__":

--- a/torappu/lookup.py
+++ b/torappu/lookup.py
@@ -1,0 +1,243 @@
+"""Resolve asset/bundle names to cached (or freshly downloaded) asset bundles.
+
+Intended for reverse-engineering workflows: given an asset name seen in
+gamedata or a bundle name, tell which bundle contains it, fetch the bundle
+from the CDN (reusing the shared cache), and optionally dump deserialized
+typetrees of every GameObject tree inside.
+
+Usage::
+
+    uv run python -m torappu.lookup battle/prefabs/[uc]projectiles/projectile_chr_turdus
+    uv run python -m torappu.lookup --resolve-only charpack/char_4224_turdus.ab
+    uv run python -m torappu.lookup --search turdus
+    uv run python -m torappu.lookup --dump /tmp/dump --res 26-08-07-14-53-29_30b8f0 \
+        "battle/prefabs/[uc]projectiles/projectile_chr_turdus"
+"""
+
+import json
+import re
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import click
+import httpx
+import UnityPy
+from UnityPy.classes import Object
+
+import torappu.core  # noqa: F401  (patches DECOMPRESSION_MAP for custom lz4)
+from torappu.consts import (
+    GAMEDATA_DIR,
+    HG_CN_BASEURL,
+    HOT_UPDATE_LIST_DIR,
+    RESOURCE_MANIFEST_IDX_NAME,
+    STORAGE_DIR,
+)
+from torappu.core.utils.path import hg_normalize_url
+from torappu.models import ABInfo, HotUpdateInfo
+
+_SNAPSHOT_PATTERN = re.compile(r"^\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+$")
+MAX_SEARCH_RESULTS = 50
+
+
+def _latest_res_version() -> str:
+    snapshots = sorted(
+        p.name
+        for p in GAMEDATA_DIR.iterdir()
+        if p.is_dir() and _SNAPSHOT_PATTERN.match(p.name)
+    )
+    if not snapshots:
+        raise click.ClickException(
+            f"no gamedata snapshot under {GAMEDATA_DIR}; run the sync pipeline first"
+        )
+    return snapshots[-1]
+
+
+def _load_manifest_idx(res_version: str) -> dict[str, str]:
+    idx_path = GAMEDATA_DIR / res_version / RESOURCE_MANIFEST_IDX_NAME
+    if not idx_path.exists():
+        raise click.ClickException(
+            f"{idx_path} not found; run the sync pipeline for {res_version} first"
+        )
+    idx = json.loads(idx_path.read_text(encoding="utf-8"))
+    bundles = idx["bundles"]
+    return {
+        item["assetName"]: bundles[item["bundleIndex"]]["name"]
+        for item in idx["assetToBundleList"]
+    }
+
+
+def _load_hot_update_list(res_version: str) -> HotUpdateInfo:
+    path = HOT_UPDATE_LIST_DIR / res_version
+    if not path.exists():
+        raise click.ClickException(
+            f"{path} not found; run the sync pipeline for {res_version} first"
+        )
+    return HotUpdateInfo.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _download_bundle(info: ABInfo, res_version: str) -> Path:
+    """Mirror Client.fetch_asset_bundle caching (md5-named, crc for 4-char md5)."""
+    dest = STORAGE_DIR / "assetbundle" / info.md5
+    if len(info.md5) != 4 and dest.exists():
+        return dest
+
+    filename = f"{hg_normalize_url(info.name.rsplit('.')[0])}.dat"
+    url = HG_CN_BASEURL.join(f"{res_version}/{filename}")
+    with httpx.Client(timeout=120) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        content = resp.content
+
+    with zipfile.ZipFile(BytesIO(content)) as bundle_zip:
+        blob = bundle_zip.read(bundle_zip.filelist[0])
+
+    if len(info.md5) == 4:
+        crc = resp.headers["x-oss-hash-crc64ecma"]
+        dest = STORAGE_DIR / "assetbundle" / crc
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(blob)
+    return dest
+
+
+def _sanitize(name: str) -> str:
+    return re.sub(r"[^0-9A-Za-z_.-]+", "_", name)
+
+
+def _dump_bundle(path: Path, dump_dir: Path) -> None:
+    env = UnityPy.load(str(path))
+    dump_dir.mkdir(parents=True, exist_ok=True)
+
+    index: list[dict[str, Any]] = []
+
+    def walk_game_object(go: Object, depth: int = 0) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        data = go.read()
+        entry: dict[str, Any] = {
+            "gameObject": data.m_Name,
+            "depth": depth,
+            "components": [],
+        }
+        for comp in data.m_Components:
+            try:
+                obj = comp.deref()
+            except Exception:
+                continue
+            if obj is None:
+                continue
+            if obj.type.name == "Transform":
+                for child in obj.read().m_Children:
+                    try:
+                        child_go = child.deref()
+                    except Exception:
+                        continue
+                    if child_go is not None and child_go.type.name == "GameObject":
+                        entries.extend(walk_game_object(child_go, depth + 1))
+                continue
+            record = {"type": obj.type.name, "pathID": obj.path_id, "file": None}
+            if obj.type.name == "MonoBehaviour":
+                try:
+                    tree = obj.read_typetree()
+                except Exception as exc:
+                    record["error"] = repr(exc)
+                else:
+                    fname = f"{obj.path_id}.json"
+                    (dump_dir / fname).write_text(
+                        json.dumps(tree, ensure_ascii=False, indent=1, default=str),
+                        encoding="utf-8",
+                    )
+                    record["file"] = fname
+            entry["components"].append(record)
+        entries.append(entry)
+        return entries
+
+    for obj in env.objects:
+        if obj.type.name == "GameObject":
+            index.extend(walk_game_object(obj))
+
+    (dump_dir / "index.json").write_text(
+        json.dumps(index, ensure_ascii=False, indent=1, default=str), encoding="utf-8"
+    )
+    click.echo(f"dumped typetrees to {dump_dir} (index.json describes the tree)")
+
+
+@click.command(
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.argument("name", nargs=-1)
+@click.option("--res", "res_version", default=None, help="res_version snapshot")
+@click.option("--resolve-only", is_flag=True, help="only print mapping, no download")
+@click.option("--search", is_flag=True, help="treat NAME as substring and list matches")
+@click.option(
+    "--dump",
+    "dump_dir",
+    type=click.Path(),
+    default=None,
+    help="dump typetrees to DIR",
+)
+def cli(
+    name: tuple[str, ...],
+    res_version: str | None,
+    resolve_only: bool,
+    search: bool,
+    dump_dir: str | None,
+):
+    if not name:
+        raise click.ClickException("NAME is required")
+    res_version = res_version or _latest_res_version()
+    asset_to_bundle = _load_manifest_idx(res_version)
+    hot_update = _load_hot_update_list(res_version)
+    bundle_names = {info.name for info in hot_update.ab_infos}
+
+    if search:
+        for n in name:
+            matches = [
+                (asset, bundle)
+                for asset, bundle in asset_to_bundle.items()
+                if n.lower() in asset.lower()
+            ]
+            matches.sort()
+            click.echo(f"# '{n}': {len(matches)} asset matches")
+            for asset, bundle in matches[:MAX_SEARCH_RESULTS]:
+                click.echo(f"{asset}\t{bundle}")
+        return
+
+    for n in name:
+        bundle = asset_to_bundle.get(n)
+        if bundle is None:
+            if n in bundle_names:
+                bundle = n
+            else:
+                partial = [
+                    (asset, b) for asset, b in asset_to_bundle.items() if n in asset
+                ]
+                if len(partial) == 1:
+                    bundle = partial[0][1]
+                    click.echo(f"# '{n}' resolved to unique asset {partial[0][0]}")
+                else:
+                    click.echo(
+                        f"# '{n}': not a known asset/bundle name "
+                        f"({len(partial)} substring matches; use --search to list)"
+                    )
+                    continue
+        ab_name = bundle if bundle.endswith(".ab") else f"{bundle}.ab"
+        info = next(
+            (i for i in hot_update.ab_infos if i.name == ab_name),
+            None,
+        )
+        if info is None:
+            click.echo(f"# '{n}' -> {ab_name}: not in hot_update_list")
+            continue
+        click.echo(f"{n} -> {ab_name} (md5 {info.md5}, {info.total_size} bytes)")
+
+        if resolve_only:
+            continue
+        path = _download_bundle(info, res_version)
+        click.echo(f"bundle at {path}")
+        if dump_dir:
+            _dump_bundle(path, Path(dump_dir) / _sanitize(ab_name))
+
+
+if __name__ == "__main__":
+    cli()

--- a/torappu/lookup.py
+++ b/torappu/lookup.py
@@ -24,7 +24,7 @@ from typing import Any
 import click
 import httpx
 import UnityPy
-from UnityPy.classes import Object
+from UnityPy.files.ObjectReader import ObjectReader
 
 import torappu.core  # noqa: F401  (patches DECOMPRESSION_MAP for custom lz4)
 from torappu.consts import (
@@ -111,7 +111,7 @@ def _dump_bundle(path: Path, dump_dir: Path) -> None:
 
     index: list[dict[str, Any]] = []
 
-    def walk_game_object(go: Object, depth: int = 0) -> list[dict[str, Any]]:
+    def walk_game_object(go: ObjectReader, depth: int = 0) -> list[dict[str, Any]]:
         entries: list[dict[str, Any]] = []
         data = go.read()
         entry: dict[str, Any] = {


### PR DESCRIPTION
添加 torappu/lookup.py，支持子串搜索、仅解析名称及导出 prefab中每个 GameObject 树的 MonoBehaviour typetree（含 index.json）， 复用共享的 storage/assetbundle 缓存与 CDN 下载流程；

ai看机制实现的时候遇到的三个操作