### PR TITLE
feat: export per-asset background ppu sidecar (background.json)

### DIFF
--- a/torappu/core/tasks/avg.py
+++ b/torappu/core/tasks/avg.py
@@ -534,6 +534,33 @@ class Task(BaseTask):
         output_path.parent.mkdir(parents=True, exist_ok=True)
         sprite.image.save(output_path)
 
+    def _collect_background_ppu(
+        self,
+        sprite: Sprite,
+        container_path: str,
+        ppus: dict[str, float],
+    ) -> None:
+        # The client sizes the background Image via `Image.SetNativeSize()` as
+        # `sprite.rect / ppu * 100` (canvas referencePixelsPerUnit = 100), and
+        # AVG background art ships a per-asset tuned ppu, so the rendered size
+        # generally differs from the texture's pixel size (e.g. bg_cher_1:
+        # 1024x576 texture, ppu 68.2464 -> 1500.44x844 centered overscan).
+        # The exported PNG already carries rect, so recording ppu alone lets
+        # consumers derive the native display rect.
+        ppu = float(sprite.m_PixelsToUnits)
+        if ppu <= 0:
+            return
+        ppus[self._container_filename(container_path)] = ppu
+
+    @staticmethod
+    def _load_json_object(path: Path) -> dict[str, object]:
+        if not path.exists():
+            return {}
+        current = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(current, dict):
+            raise ValueError(f"Unexpected json format at {path}")
+        return current
+
     @classmethod
     def _compact_character_links(
         cls, key: str, character_data: CharacterLinkData
@@ -590,9 +617,10 @@ class Task(BaseTask):
 
     async def unpack(
         self, env: UnityPy.Environment, unpacking_source: list[str]
-    ) -> dict[str, CharacterDataJson]:
+    ) -> tuple[dict[str, CharacterDataJson], dict[str, float]]:
         container_map = build_container_path(env)
         character_links: dict[str, CharacterDataJson] = {}
+        background_ppus: dict[str, float] = {}
 
         for obj in env.objects:
             source = get_source(obj)
@@ -609,18 +637,21 @@ class Task(BaseTask):
                 continue
 
             if container_path.startswith(BG_CONTAINER_PREFIX):
-                if texture := read_obj(Sprite, obj):
-                    self._extract_sprite(texture, "background", container_path)
+                if sprite := read_obj(Sprite, obj):
+                    self._extract_sprite(sprite, "background", container_path)
+                    self._collect_background_ppu(
+                        sprite, container_path, background_ppus
+                    )
                 continue
 
             if container_path.startswith(
                 (IMAGE_CONTAINER_PREFIX, ITEM_CONTAINER_PREFIX)
             ):
-                if texture := read_obj(Sprite, obj):
-                    self._extract_sprite(texture, "images", container_path)
+                if sprite := read_obj(Sprite, obj):
+                    self._extract_sprite(sprite, "images", container_path)
                 continue
 
-        return character_links
+        return character_links, background_ppus
 
     def check(self, diff_list: list[Diff]) -> bool:
         diff_set = {diff.path for diff in diff_list}
@@ -646,20 +677,21 @@ class Task(BaseTask):
             Path(resolved_path).name for resolved_path in resolved_paths
         ]
         env = UnityPy.load(*self.client.anon_paths, *resolved_paths)
-        character_links = await self.unpack(env, resolved_filenames)
+        character_links, background_ppus = await self.unpack(env, resolved_filenames)
+
+        if background_ppus:
+            background_ppu_path = BASE_DIR.joinpath("background.json")
+            background_data = self._load_json_object(background_ppu_path)
+            background_data.update(background_ppus)
+            background_ppu_path.write_text(
+                json.dumps(background_data, ensure_ascii=False), encoding="utf-8"
+            )
+
         if len(character_links) == 0:
             return
 
         character_link_path = BASE_DIR.joinpath("character.json")
-        if character_link_path.exists():
-            current_data = json.loads(character_link_path.read_text(encoding="utf-8"))
-            if not isinstance(current_data, dict):
-                raise ValueError(
-                    f"Unexpected character json format at {character_link_path}"
-                )
-        else:
-            current_data: dict[str, CharacterDataJson] = {}
-
+        current_data = self._load_json_object(character_link_path)
         current_data.update(character_links)
         character_link_path.write_text(
             json.dumps(current_data, ensure_ascii=False), encoding="utf-8"

--- a/torappu/core/tasks/avg.py
+++ b/torappu/core/tasks/avg.py
@@ -1,6 +1,7 @@
 import json
 import re
 from dataclasses import dataclass
+from math import isfinite
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypedDict, cast
 
@@ -524,13 +525,17 @@ class Task(BaseTask):
             game_object_name, char_link
         )
 
-    def _extract_sprite(self, sprite: Sprite, subdir: str, container_path: str):
+    @staticmethod
+    def _sprite_filename(container_path: str) -> str:
         file_name = Path(container_path).name
         if file_name == "":
             raise ValueError("Empty container path when extracting avg sprite")
         if not file_name.lower().endswith(".png"):
             file_name = f"{file_name}.png"
-        output_path = BASE_DIR.joinpath(subdir, file_name)
+        return file_name
+
+    def _extract_sprite(self, sprite: Sprite, subdir: str, container_path: str):
+        output_path = BASE_DIR.joinpath(subdir, self._sprite_filename(container_path))
         output_path.parent.mkdir(parents=True, exist_ok=True)
         sprite.image.save(output_path)
 
@@ -548,9 +553,17 @@ class Task(BaseTask):
         # The exported PNG already carries rect, so recording ppu alone lets
         # consumers derive the native display rect.
         ppu = float(sprite.m_PixelsToUnits)
-        if ppu <= 0:
-            return
-        ppus[self._container_filename(container_path)] = ppu
+        if not isfinite(ppu) or ppu <= 0:
+            # A non-positive ppu makes SetNativeSize divide by zero, and a
+            # non-finite one serializes as bare `NaN`/`Infinity`, which is not
+            # valid JSON and would break the whole sidecar for consumers.
+            raise ValueError(
+                f"Invalid sprite pixelsPerUnit {ppu!r} at {container_path}"
+            )
+        # Key on the exported PNG's stem rather than the container stem: the
+        # consumer looks the ppu up by the name it fetched the PNG under, and
+        # `_sprite_filename` is what decides that name.
+        ppus[Path(self._sprite_filename(container_path)).stem] = ppu
 
     @staticmethod
     def _load_json_object(path: Path) -> dict[str, object]:


### PR DESCRIPTION
## 背景:背景资源的 ppu 逐资产调参

官服客户端(2.7.61)对 AVG 背景的尺寸链路里,`AVGImagePanel._LoadImage` 在 set sprite 之后立即调 `Image.SetNativeSize()`。该 build(HG 魔改 uGUI)的 SetNativeSize 做三件事:

1. `anchorMax = anchorMin`(@ 0x186762dc1)—— 把 prefab 上拉伸铺满的背景 Image 锚点收成点锚;
2. `sizeDelta = sprite.rect ÷ Image.pixelsPerUnit`(@ 0x186762f6d;ppu = sprite.ppu ÷ canvas.referencePixelsPerUnit(100))。

即背景的**原生渲染尺寸不是纹理像素尺寸**,而是 `纹理尺寸 × 100 ÷ sprite.ppu`。而 AVG 背景资源的 ppu 是逐资产调参的(官服 2.7.61 全部 1021 个 `avg/backgrounds` sprite 共 7 种取值):

| ppu | 数量 | 典型渲染尺寸 | 缺省 screenadapt 观感(1280×720 画布) |
| --- | --- | --- | --- |
| 80 | 554 | 1024×576 纹理 → 1280×720 | 精确铺满 |
| 100 | 350 | 1280×720 → 1280×720(15);1024×576 → 1024×576(318) | 前者铺满,**318 张露底色** |
| 68.2464 | 101 | 1024×576 → 1500.44×844(bg_cher_*、bg_ri_1 等 2019 首发批次) | 超采样 1.1725× 居中裁边铺满 |
| 64 / 53.3333 / 97.1537 / 56.8608 | 16 | 1600×900、1920×720 等特例 | 各自超采样 |

例:`bg_cher_1` 纹理 1024×576、ppu 68.2464 → 渲染 1500.44×844,超采样居中裁边铺满 —— 这就是游戏里背景占满屏幕的原因。**仅凭导出的 PNG 无法还原 ppu**,消费方(prts-widgets StoryPlayer)此前只能把 PNG 像素尺寸当原生尺寸,渲染结果与游戏不一致(该带裁边的没裁边、该露底色的被拉伸)。

## 变更

- avg task 在导出背景 PNG 的同时收集 `sprite.m_PixelsToUnits`,写出 **`BASE_DIR/background.json`**(key → ppu 的扁平 map,与 `character.json` 同目录、同样的读-合-写合并语义;写在 character-only early return 之前,纯背景增量运行也能产出);
- key = bundle container 路径 stem(全小写,与导出 PNG 文件名一致)。1021 个 sprite 中 99 个 `m_Name` 保留大写(如 `21_G7_*`、`bg_Festival_2`),不能用 m_Name 当 key,否则消费方查表落空;
- `character.json` 的读入块提炼为 `_load_json_object()` 共用;
- `read_obj(Sprite, obj)` 的误导性变量名 `texture` → `sprite`(纯改名)。

消费公式:`原生渲染尺寸 = PNG尺寸 ÷ ppu × 100`。

## 验证

- 本地全量:162 个背景 bundle → `background.json` 1021 个 key(29KB),与独立提取脚本(arknights-rev/avg-asset-ppu)的参考数据逐条零偏差(ppu 直方图 80×554 / 100×350 / 68.2464×101 / 64×9 / 53.3333×4 / 97.1537×2 / 56.8608×1);
- 单 bundle 烟雾测试:unpack 全路径(PNG 导出 + ppu 收集)正常,导出 PNG 尺寸 = `m_Rect`(即 sidecar 的 rect 载体就是 PNG 本身);
- `ruff check` / `ruff format` 通过。

## 下游

prts-widgets#356 已改为在 StoryPlayer 启动时与 `character.json` 同模式并行拉取 `assets/avg/background.json` 并现算原生渲染尺寸;sidecar 未部署时静默走兜底,部署到资源站后自动生效,无需 widget 再发版。
